### PR TITLE
[提案] add support Crawling URL test

### DIFF
--- a/normalizer_test.go
+++ b/normalizer_test.go
@@ -25,6 +25,7 @@ type testData struct {
 	In    string `json:"in"`
 	N1URL string `json:"n1url"`
 	N2URL string `json:"n2url"`
+	CURL  string `json:"curl"`
 }
 
 func TestNormalization(t *testing.T) {
@@ -59,8 +60,8 @@ func parseTestFile(fn string) (*testFile, error) {
 
 func testNormalize(t *testing.T, tests []testData) {
 	for _, tt := range tests {
-		if tt.N1URL == "" && tt.N2URL == "" {
-			t.Errorf("%s: n1url or n2url is required", tt.In)
+		if tt.CURL == "" && tt.N1URL == "" && tt.N2URL == "" {
+			t.Errorf("%s: curl, n1url or n2url is required", tt.In)
 			continue
 		}
 		ul, err := url.Parse(tt.In)
@@ -68,6 +69,13 @@ func testNormalize(t *testing.T, tests []testData) {
 			t.Errorf("%v : %v", tt.In, err)
 		}
 		t.Run(ul.Host+ul.Path, func(t *testing.T) {
+			if tt.CURL != "" {
+				result := urls.CrawlingURL(ul)
+				if result != tt.CURL {
+					t.Errorf("curl:\nwant '%v'\n got '%v'", tt.CURL, result)
+				}
+			}
+
 			if tt.N1URL != "" {
 				result := urls.FirstNormalizeURL(ul)
 				if result != tt.N1URL {

--- a/testdata/optimized_url.json
+++ b/testdata/optimized_url.json
@@ -115,11 +115,11 @@
     },
     {
       "in": "https://itest.5ch.net/foo/test/read.cgi/abc/00000000",
-      "n1url": "http://foo.5ch.net/test/read.cgi/abc/00000000/"
+      "curl": "https://foo.5ch.net/test/read.cgi/abc/00000000"
     },
     {
       "in": "https://itest.bbspink.com/bar/test/read.cgi/xyz/000000",
-      "n1url": "http://bar.bbspink.com/test/read.cgi/xyz/000000/"
+      "curl": "https://bar.bbspink.com/test/read.cgi/xyz/000000"
     },
     {
       "description": "unoptimizable",

--- a/testdata/optimized_url.json
+++ b/testdata/optimized_url.json
@@ -115,11 +115,13 @@
     },
     {
       "in": "https://itest.5ch.net/foo/test/read.cgi/abc/00000000",
-      "curl": "https://foo.5ch.net/test/read.cgi/abc/00000000"
+      "curl": "https://foo.5ch.net/test/read.cgi/abc/00000000",
+      "n1url": "http://foo.5ch.net/test/read.cgi/abc/00000000/"
     },
     {
       "in": "https://itest.bbspink.com/bar/test/read.cgi/xyz/000000",
-      "curl": "https://bar.bbspink.com/test/read.cgi/xyz/000000"
+      "curl": "https://bar.bbspink.com/test/read.cgi/xyz/000000",
+      "n1url": "http://bar.bbspink.com/test/read.cgi/xyz/000000/"
     },
     {
       "description": "unoptimizable",


### PR DESCRIPTION
今回の場合、Crawling URL をテストした方が良いのではないでしょうか？
あるいは N1URL をテストすれば十分でしょうか？

外部向けのテストでもあるので、不要ならn1url だけの方が良いと思います。