### PR TITLE
add AdMind URL optimizer 

### DIFF
--- a/lib/urls/host_test.go
+++ b/lib/urls/host_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func Test_normalizePath(t *testing.T) {
-
 	testPaths := []string{
 		"example1.com,1,",
 		"example2.com,2,",
@@ -69,7 +68,6 @@ func Test_normalizePath(t *testing.T) {
 }
 
 func Test_normalizeSPHost(t *testing.T) {
-
 	testHosts := []string{
 		"sp.example1.com,www.example1.com",
 		"sp.example2.com,example2.com",

--- a/lib/urls/optimize.go
+++ b/lib/urls/optimize.go
@@ -50,6 +50,7 @@ var (
 		"megalodon.jp":                    parseAdframeURL("url"),
 		"ad.deqwas-dsp.net":               parseAdframeURL("url"),
 		"krad20.deqwas.net":               parseAdframeURL("u"),
+		"bidresult-dsp.ad-m.asia":         parseAdframeURL("rf"),
 		"itest.5ch.net":                   optimizeItest5chURL,
 		"itest.bbspink.com":               optimizeItest5chURL,
 	}
@@ -66,7 +67,11 @@ func optimizeURL(ul *url.URL) *url.URL {
 func parseAdframeURL(key string) func(*url.URL) *url.URL {
 	return func(ul *url.URL) *url.URL {
 		if raw, ok := ul.Query()[key]; ok {
-			u, err := url.Parse(raw[0])
+			ref := raw[0]
+			if !strings.HasPrefix(ref, "http://") && !strings.HasPrefix(ref, "https://") {
+				ref = "http://" + ref
+			}
+			u, err := url.Parse(ref)
 			if err == nil {
 				return u
 			}

--- a/lib/urls/optimize_test.go
+++ b/lib/urls/optimize_test.go
@@ -1,0 +1,155 @@
+// Copyright 2017 Momentum K.K. All rights reserved.
+// This source code or any portion thereof must not be
+// reproduced or used in any manner whatsoever.
+
+// Package urls normalizes URLs and implements its helpers
+package urls
+
+import (
+	"net/url"
+	"reflect"
+	"testing"
+)
+
+// See also: https://golang.org/src/net/url/url_test.go
+// nolint:funlen
+func Test_parsePotentialURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		arg     string
+		want    *url.URL
+		wantErr bool
+	}{
+		{
+			"minimal URL",
+			"http://www.example.com",
+			&url.URL{
+				Scheme: "http",
+				Host:   "www.example.com",
+			},
+			false,
+		},
+		{
+			"ordinal URL",
+			"https://www.example.com:8080/path/to/page.html?x=1#99",
+			&url.URL{
+				Scheme:   "https",
+				Host:     "www.example.com:8080",
+				Path:     "/path/to/page.html",
+				RawQuery: "x=1",
+				Fragment: "99",
+			},
+			false,
+		},
+		{
+			"capital scheme",
+			"HTTP://www.example.com",
+			&url.URL{
+				Scheme: "http",
+				Host:   "www.example.com",
+			},
+			false,
+		},
+		{
+			"non-http but common scheme URL",
+			"ftp://ftp.example.com/bar",
+			&url.URL{
+				Scheme: "ftp",
+				Host:   "ftp.example.com",
+				Path:   "/bar",
+			},
+			false,
+		},
+		{
+			"non-http scheme URL with port",
+			"ftp://ftp.example.com:10022/bar",
+			&url.URL{
+				Scheme: "ftp",
+				Host:   "ftp.example.com:10022",
+				Path:   "/bar",
+			},
+			false,
+		},
+		{
+			"non-http scheme URL without authority part",
+			"ftp://ftp.example.com:10022/bar",
+			&url.URL{
+				Scheme: "ftp",
+				Host:   "ftp.example.com:10022",
+				Path:   "/bar",
+			},
+			false,
+		},
+		{ // See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
+			"non-http uncommon scheme URL",
+			"data:text/html,%3Ch1%3EHello%2C%20World!%3C%2Fh1%3E",
+			&url.URL{
+				Scheme: "data",
+				Opaque: "text/html,%3Ch1%3EHello%2C%20World!%3C%2Fh1%3E",
+			},
+			false,
+		},
+		{
+			"without scheme",
+			"www.example.com/foo",
+			&url.URL{
+				Scheme: "http",
+				Host:   "www.example.com",
+				Path:   "/foo",
+			},
+			false,
+		},
+		{
+			"without scheme with port",
+			"www.example.com:8080/foo",
+			&url.URL{
+				Scheme: "http",
+				Host:   "www.example.com:8080",
+				Path:   "/foo",
+			},
+			false,
+		},
+		{
+			"multibyte hostname without scheme",
+			"hello.世界.com/foo",
+			&url.URL{
+				Scheme: "http",
+				Host:   "hello.世界.com",
+				Path:   "/foo",
+			},
+			false,
+		},
+		{
+			"multibyte hostname with port",
+			"http://hello.世界.com:8080/foo",
+			&url.URL{
+				Scheme: "http",
+				Host:   "hello.世界.com:8080",
+				Path:   "/foo",
+			},
+			false,
+		},
+		{
+			"multibyte hostname with port without scheme",
+			"hello.世界.com:8080/foo",
+			&url.URL{
+				Scheme: "http",
+				Host:   "hello.世界.com:8080",
+				Path:   "/foo",
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parsePotentialURL(tt.arg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parsePotentialURL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parsePotentialURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/testdata/optimized_url.json
+++ b/testdata/optimized_url.json
@@ -114,6 +114,17 @@
       "n1url": "http://www.example.com/foo/bar/9999999999999999999/?page=2"
     },
     {
+      "description": "optimizable AdMind URL",
+      "in": "http://bidresult-dsp.ad-m.asia/dsp/api/sbid/b/?a=XXXX&adtype=0&afe=YYYY&at=0&b=0&bd=ZZZZZZ8&ds=0&h=50&id=0000000000&kt=0&mp=0&ot=0&pi=0000&pos=0&pr=00&rbs=1&rd=https%3A%2F%2Fad.example.com&rf=blog.foo.jp%2Fxyz&s=0&tpsid=0000000000&w=320",
+      "curl": "http://blog.foo.jp/xyz",
+      "n1url": "http://blog.foo.jp/xyz/"
+    },
+    {
+      "description": "non optimizable AdMind URL (missing `rf` query param)",
+      "in": "http://bidresult-dsp.ad-m.asia/dsp/api/sbid/b/?a=XXXX&adtype=0&afe=YYYY&at=0&b=0&bd=ZZZZZZ8&ds=0&h=50&id=0000000000&kt=0&mp=0&ot=0&pi=0000&pos=0&pr=00&rbs=1&rd=https%3A%2F%2Fad.example.com&rrf=blog.foo.jp%2Fxyz&s=0&tpsid=0000000000&w=320",
+      "n1url": "http://bidresult-dsp.ad-m.asia/dsp/api/sbid/b/?a=XXXX&adtype=0&afe=YYYY&at=0&b=0&bd=ZZZZZZ8&ds=0&h=50&id=0000000000&kt=0&mp=0&ot=0&pi=0000&pos=0&pr=00&rbs=1&rd=https%3A%2F%2Fad.example.com&rrf=blog.foo.jp%2Fxyz&s=0&tpsid=0000000000&w=320"
+    },
+    {
       "in": "https://itest.5ch.net/foo/test/read.cgi/abc/00000000",
       "curl": "https://foo.5ch.net/test/read.cgi/abc/00000000",
       "n1url": "http://foo.5ch.net/test/read.cgi/abc/00000000/"
@@ -136,7 +147,7 @@
       "n1url": "http://itest.bbspink.com/test/read.cgi/xyz/000000/"
     },
     {
-      "description": "unoptimizable",
+      "description": "non-optimizable",
       "in":"https://pubads.g.doubleclick.net/gampad/ads?_activity_context=true&android_num_video_cache_tasks=0&caps=inlineVideo_interactiveVideo_mraid1_mraid2_sdkVideo_th_autoplay_mediation_av_transparentBackground_sdkAdmobApiForAds_di_aso_sfv_dinm_dim_dinmo_gcache&eid=999999999%2C999999999%2C999999999&format=320x50_mb&heap_free=9999999&heap_max=999999999&heap_total=99999999&js=afma-sdk-a-v11746038.9452000.2&mr=99999999999999999%2C-999999999999999999%2C9999999999999999999%2C-9999999999999999999%2C-9999999999999999999%",
       "n1url":"http://pubads.g.doubleclick.net/gampad/ads/?_activity_context=true&android_num_video_cache_tasks=0&caps=inlineVideo_interactiveVideo_mraid1_mraid2_sdkVideo_th_autoplay_mediation_av_transparentBackground_sdkAdmobApiForAds_di_aso_sfv_dinm_dim_dinmo_gcache&eid=999999999%2C999999999%2C999999999&format=320x50_mb&heap_free=9999999&heap_max=999999999&heap_total=99999999&js=afma-sdk-a-v11746038.9452000.2"
     }


### PR DESCRIPTION
### Optimize target

- host: bidresult-dsp.ad-m.asia, query_param: `rf`

### related upadtes

- set-if-empty `http://` protocol header after extracting real page URL value from query parameters of base URL
    - non http scheme like `ftp://` or `data:` won't be overriden 