### PR TITLE
WIP implement AMP cache URL optimizer

### DIFF
--- a/lib/urls/normalizer_r.go
+++ b/lib/urls/normalizer_r.go
@@ -37,11 +37,10 @@ func NewNormalizerR(ul *url.URL) (n *NormalizerR, err error) {
 		url3 = url1
 	}
 
-	// allocate and copy
-	newUl := *ul
+	newUl := cloneURL(ul)
 
 	n = &NormalizerR{
-		url:   &newUl,
+		url:   newUl,
 		n1URL: url1,
 		n2URL: url2,
 		cURL:  url3,

--- a/lib/urls/optimize.go
+++ b/lib/urls/optimize.go
@@ -318,10 +318,10 @@ LOOP:
 		host = rawPath[hostPos:]
 	}
 
-	realURL := *u
+	realURL := cloneURL(u)
 	realURL.Scheme = scheme
 	realURL.Host = host
 	realURL.Path = path
 
-	return &realURL
+	return realURL
 }

--- a/lib/urls/optimize.go
+++ b/lib/urls/optimize.go
@@ -255,3 +255,73 @@ func parsePotentialURL(rawurl string) (*url.URL, error) {
 
 	return parsed, nil // non-http scheme URL (e.g. ftp://example.com/bar, data:,Hello%2C%20World!, etc)
 }
+
+// optimizeAMPCacheURL gets original URL from AMP Cache URL
+//
+// AMP Cache URL Format:
+// https://amp.dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/amp-cache-urls/
+func optimizeAMPCacheURL(u *url.URL) *url.URL {
+	rawPath := u.Path
+
+	hostPos := -1
+	scheme := "http"
+	host := ""
+	path := ""
+
+LOOP:
+	// skip first "/"
+	for pos := 1; pos < len(rawPath); {
+		next := strings.Index(rawPath[pos:], "/") + pos
+		if next < pos {
+			// it looks final part of path
+			hostPos = pos
+			break LOOP
+		}
+
+		part := rawPath[pos:next]
+
+		switch part {
+		case "c": // Content
+		case "v": // Viewer
+		case "wp": // Web Package
+			// nothing to do
+
+		case "cert": // Certificate
+		case "i": // Image
+		case "ii": // Image
+			// As I think, we will never receive above ones
+
+		case "":
+			// empty
+		case "s":
+			// Original URL is HTTPS
+			scheme = "https"
+		default:
+			// not AMP prefix directory, beginning of original URL
+			hostPos = pos
+			break LOOP
+		}
+
+		pos = next + 1 // skip "/" char
+	}
+
+	if hostPos < 0 {
+		// host part not found in path
+		return u
+	}
+
+	pathPos := strings.Index(rawPath[hostPos:], "/") + hostPos
+	if pathPos > hostPos {
+		host = rawPath[hostPos:pathPos]
+		path = rawPath[pathPos:]
+	} else {
+		host = rawPath[hostPos:]
+	}
+
+	realURL := *u
+	realURL.Scheme = scheme
+	realURL.Host = host
+	realURL.Path = path
+
+	return &realURL
+}

--- a/lib/urls/optimize_test.go
+++ b/lib/urls/optimize_test.go
@@ -153,3 +153,68 @@ func Test_parsePotentialURL(t *testing.T) {
 		})
 	}
 }
+
+func TestOptimizeAMPCacheURL(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  string
+		want *url.URL
+	}{
+		{
+			"simple URL",
+			"https://amp-dev.cdn.ampproject.org/c/s/amp.dev/index.amp.html",
+			&url.URL{
+				Scheme: "https",
+				Host:   "amp.dev",
+				Path:   "/index.amp.html",
+			},
+		},
+		{
+			"URL with parameter and fragment",
+			"https://amp-dev.cdn.ampproject.org/c/s/amp.dev/amp/index.html?param=123#Head",
+			&url.URL{
+				Scheme:   "https",
+				Host:     "amp.dev",
+				Path:     "/amp/index.html",
+				Fragment: "Head",
+				RawQuery: "param=123",
+			},
+		},
+		{
+			"top page URL (no path)",
+			"https://amp-example-com.cdn.ampproject.org/c/amp.example.com",
+			&url.URL{
+				Scheme: "http",
+				Host:   "amp.example.com",
+			},
+		},
+		{
+			"empty URL (http://) fails to optimize",
+			"https://4oymiquy7qobjgx36tejs35zeqt24qpemsnzgtfeswmrw6csxbkq.cdn.ampproject.org/c/",
+			&url.URL{
+				Scheme: "https",
+				Host:   "4oymiquy7qobjgx36tejs35zeqt24qpemsnzgtfeswmrw6csxbkq.cdn.ampproject.org",
+				Path:   "/c/",
+			},
+		},
+		{
+			"Japanese domain (ドメイン名例.JP)",
+			"https://xn---jp-qi4b8gof5e173yzqi.cdn.ampproject.org/c/s/xn--eckwd4c7cu47r2wf.jp/page/index.amp.html",
+			&url.URL{
+				Scheme: "https",
+				Host:   "xn--eckwd4c7cu47r2wf.jp",
+				Path:   "/page/index.amp.html",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, _ := url.Parse(tt.arg)
+			got := optimizeAMPCacheURL(u)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("optimizeAMPCacheURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/lib/urls/util.go
+++ b/lib/urls/util.go
@@ -1,0 +1,19 @@
+package urls
+
+import "net/url"
+
+func cloneURL(u *url.URL) *url.URL {
+	if u == nil {
+		return nil
+	}
+
+	u2 := new(url.URL)
+	*u2 = *u
+
+	if u.User != nil {
+		u2.User = new(url.Userinfo)
+		*u2.User = *u.User
+	}
+
+	return u2
+}


### PR DESCRIPTION
Close: #67 

optimize関数のみ試しに実装
AMP Cacheはオリジナルのドメイン名を含んだドメインにキャッシュされるため、AMP CacheのURLかどうかを判定するためには最低でも後方一致(`*.cdn.ampproject.org`)での判定が必要、どこに入れるべき?