### PR TITLE
update normalize func for url.Host

### DIFF
--- a/lib/urls/host.go
+++ b/lib/urls/host.go
@@ -34,22 +34,24 @@ func normalizeHost(ul *url.URL) {
 
 	if punycode, err := httpguts.PunycodeHostPort(rawHost); err == nil {
 		ul.Host = punycode
-	} /*  else { // FIXME: should return immediately?
-		return
-	} */
+	}
 
 	host := ul.Hostname() // '[]' for raw IPv6 address would be stripped
-	port := ul.Port()     // empty if no valid port (url.Parse() would be fail with invalid port in the first place)
+	if host == "" {       // nothing to normalize
+		return
+	}
 
-	if !strings.HasPrefix(rawHost, "[") { // except the case when rawHost is IPv6 address
-		host = strings.TrimRight(host, ".") // trimming tailing dots
+	if n := len(host); n > 1 && host[n-1] == '.' && host[n-2] != '.' { // host ends with dot except the case dots are two or more consecutive
+		if !strings.HasPrefix(rawHost, "[") { // except IPv6 address host, Discussion: https://github.com/TeamMomentum/bs-url-normalizer/pull/74#pullrequestreview-486689000
+			host = strings.TrimSuffix(host, ".") // trimming tailing single dot
+		}
 	}
 
 	host = strings.ToLower(host) // converting to lowercase
 
 	// Re-Join normalized host and original port
 	// with trimming tailing ':' because net.JoinHostPort() does not take care of empty port
-	ul.Host = strings.TrimSuffix(net.JoinHostPort(host, port), ":")
+	ul.Host = strings.TrimSuffix(net.JoinHostPort(host, ul.Port()), ":")
 }
 
 // normalizePath reduces known URLs to the top page of the website

--- a/lib/urls/normalizer.go
+++ b/lib/urls/normalizer.go
@@ -53,7 +53,7 @@ func NewNormalizer(ul *url.URL) (n *Normalizer, err error) {
 // CrawlingURL returns the preferred URL for crawling
 func (n *Normalizer) CrawlingURL() string {
 	if n.cURL == "" {
-		normalizePunycodeHost(n.url)
+		normalizeHost(n.url)
 		n.url = optimizeURL(n.url)
 		n.cURL = n.url.String()
 	}

--- a/lib/urls/normalizer_r.go
+++ b/lib/urls/normalizer_r.go
@@ -53,7 +53,7 @@ func NewNormalizerR(ul *url.URL) (n *NormalizerR, err error) {
 // CrawlingURL returns the preferred URL for crawling
 func (n *NormalizerR) CrawlingURL() string {
 	if n.cURL == "" {
-		normalizePunycodeHost(n.url)
+		normalizeHost(n.url)
 		n.url = optimizeURL(n.url)
 		n.cURL = n.url.String()
 	}

--- a/lib/urls/optimize.go
+++ b/lib/urls/optimize.go
@@ -63,7 +63,7 @@ func optimizeURL(ul *url.URL) *url.URL {
 	if cb, ok := optimizeURLMap[baseHost]; ok {
 		ul = cb(ul)
 		if ul.Host != baseHost {
-			normalizePunycodeHost(ul)
+			normalizeHost(ul)
 		}
 	}
 	return ul

--- a/testdata/non_ascii.json
+++ b/testdata/non_ascii.json
@@ -57,6 +57,26 @@
       "description": "normalize punycode won't be called if optimizeURL() do nothing",
       "in": "http://i.yimg.jp/images/listing/tool/yads/yads-iframe.html?s=&x=https%3A%2F%2Fhello.%E4%B8%96%E7%95%8C.com%2Ffoo",
       "n1url": "http://i.yimg.jp/images/listing/tool/yads/yads-iframe.html/?s=&x=https%3A%2F%2Fhello.%E4%B8%96%E7%95%8C.com%2Ffoo"
+    },
+    {
+      "description": "unicode FQDN with tailing dot",
+      "in": "http://ドメイン名例.jp.",
+      "n2url": "http://xn--eckwd4c7cu47r2wf.jp"
+    },
+    {
+      "description": "unicode FQDN containing subdomain with tailing dot",
+      "in": "http://ウィキペディア.ドメイン名例.jp.",
+      "n2url": "http://xn--cckbak0byl6e.xn--eckwd4c7cu47r2wf.jp"
+    },
+    {
+      "description": "unicode FQDN without ascii TLD with tailing dot",
+      "in": "http://例え.テスト.",
+      "n2url": "http://xn--r8jz45g.xn--zckzah"
+    },
+    {
+      "description": "URL encoded with tailing dot",
+      "in": "http://%E3%83%89%E3%83%A1%E3%82%A4%E3%83%B3%E5%90%8D%E4%BE%8B.jp.",
+      "n2url": "http://xn--eckwd4c7cu47r2wf.jp"
     }
   ]
 }

--- a/testdata/norm_host.json
+++ b/testdata/norm_host.json
@@ -10,8 +10,8 @@
 		{
 			"description": "general host with multiple tailing dots. FIXME: Is it OK to trim all of tailing dots?",
 			"in": "https://www.example.com..",
-			"n1url": "http://www.example.com/",
-			"n2url": "http://www.example.com"
+			"n1url": "http://www.example.com../",
+			"n2url": "http://www.example.com.."
 		},
 		{
 			"description": "general host with tailing dot and port",
@@ -34,8 +34,8 @@
 		{
 			"description": "IPv4 host with multiple tailing dots. FIXME: Is it OK to trim all of tailing dots?",
 			"in": "https://192.168.12.34..",
-			"n1url": "http://192.168.12.34/",
-			"n2url": "http://192.168.12.34"
+			"n1url": "http://192.168.12.34../",
+			"n2url": "http://192.168.12.34.."
 		},
 		{
 			"description": "IPv4 with tailing dot and port",
@@ -68,6 +68,12 @@
 			"n2url": "http://[2001:0db8:bd05:01d2:288a:1fc0:0001:10ee]"
 		},
 		{
+			"description": "IPv6 host with tailing dot (not to be normalize), See: https://github.com/TeamMomentum/bs-url-normalizer/pull/74#discussion_r486955428",
+			"in": "https://[2001:0db8:bd05:01d2:288a:1fc0:0001:10ee.]",
+			"n1url": "http://[2001:0db8:bd05:01d2:288a:1fc0:0001:10ee.]/",
+			"n2url": "http://[2001:0db8:bd05:01d2:288a:1fc0:0001:10ee.]"
+		},
+		{
 			"description": "IPv6 host port",
 			"in": "https://[2001:0db8:bd05:01d2:288a:1fc0:0001:10ee]:8080",
 			"n1url": "http://[2001:0db8:bd05:01d2:288a:1fc0:0001:10ee]:8080/",
@@ -78,6 +84,36 @@
 			"in": "https://[2001:0DB8:BD05:01D2:288A:1FC0:0001:10EE]",
 			"n1url": "http://[2001:0db8:bd05:01d2:288a:1fc0:0001:10ee]/",
 			"n2url": "http://[2001:0db8:bd05:01d2:288a:1fc0:0001:10ee]"
+		},
+		{
+			"description": "Invalid IPv6 host",
+			"in": "https://[2001:0db8:bd05:01d2:288a:1fc0:0001:10ee..]",
+			"n1url": "http://[2001:0db8:bd05:01d2:288a:1fc0:0001:10ee..]/",
+			"n2url": "http://[2001:0db8:bd05:01d2:288a:1fc0:0001:10ee..]"
+		},
+		{
+			"description": "empty host with path",
+			"in": "https:///a/b.html",
+			"n1url": "http:///a/b.html/",
+			"n2url": "http://"
+		},
+		{
+			"description": "host == '.'",
+			"in": "https://./a/b.html",
+			"n1url": "http://./a/b.html/",
+			"n2url": "http://."
+		},
+		{
+			"description": "host == '..'",
+			"in": "https://../a/b.html",
+			"n1url": "http://../a/b.html/",
+			"n2url": "http://.."
+		},
+		{
+			"description": "empty host (non-http scheme)",
+			"in": "mobileapp::1-com.example.app",
+			"n1url": "mobileapp::1-com.example.app",
+			"n2url": "mobileapp::1-com.example.app"
 		}
 	]
 }

--- a/testdata/norm_host.json
+++ b/testdata/norm_host.json
@@ -8,7 +8,7 @@
 			"n2url": "http://www.example.com"
 		},
 		{
-			"description": "general host with multiple tailing dots. FIXME: Is it OK to trim all of tailing dots?",
+			"description": "general host with multiple tailing dots (not to be trimmed)",
 			"in": "https://www.example.com..",
 			"n1url": "http://www.example.com../",
 			"n2url": "http://www.example.com.."
@@ -32,7 +32,7 @@
 			"n2url": "http://192.168.12.34"
 		},
 		{
-			"description": "IPv4 host with multiple tailing dots. FIXME: Is it OK to trim all of tailing dots?",
+			"description": "IPv4 host with multiple tailing dots (not to be trimmed)",
 			"in": "https://192.168.12.34..",
 			"n1url": "http://192.168.12.34../",
 			"n2url": "http://192.168.12.34.."
@@ -68,7 +68,7 @@
 			"n2url": "http://[2001:0db8:bd05:01d2:288a:1fc0:0001:10ee]"
 		},
 		{
-			"description": "IPv6 host with tailing dot (not to be normalize), See: https://github.com/TeamMomentum/bs-url-normalizer/pull/74#discussion_r486955428",
+			"description": "IPv6 host with tailing dot (not to be trimmed), See: https://github.com/TeamMomentum/bs-url-normalizer/pull/74#discussion_r486955428",
 			"in": "https://[2001:0db8:bd05:01d2:288a:1fc0:0001:10ee.]",
 			"n1url": "http://[2001:0db8:bd05:01d2:288a:1fc0:0001:10ee.]/",
 			"n2url": "http://[2001:0db8:bd05:01d2:288a:1fc0:0001:10ee.]"

--- a/testdata/norm_host.json
+++ b/testdata/norm_host.json
@@ -1,0 +1,83 @@
+{
+	"description": "ホスト部の正規化に関するテスト",
+	"tests": [
+		{
+			"description": "general host with tailing dot",
+			"in": "https://www.example.com.",
+			"n1url": "http://www.example.com/",
+			"n2url": "http://www.example.com"
+		},
+		{
+			"description": "general host with multiple tailing dots. FIXME: Is it OK to trim all of tailing dots?",
+			"in": "https://www.example.com..",
+			"n1url": "http://www.example.com/",
+			"n2url": "http://www.example.com"
+		},
+		{
+			"description": "general host with tailing dot and port",
+			"in": "https://www.example.com.:8080",
+			"n1url": "http://www.example.com:8080/",
+			"n2url": "http://www.example.com:8080"
+		},
+		{
+			"description": "general host with tailing dot, path, query, and hash",
+			"in": "https://www.example.com./PATH/to/Page?Xa=UP#ABC",
+			"n1url": "http://www.example.com/PATH/to/Page/?Xa=UP#ABC",
+			"n2url": "http://www.example.com"
+		},
+		{
+			"description": "IPv4 host with tailing dot",
+			"in": "https://192.168.12.34.",
+			"n1url": "http://192.168.12.34/",
+			"n2url": "http://192.168.12.34"
+		},
+		{
+			"description": "IPv4 host with multiple tailing dots. FIXME: Is it OK to trim all of tailing dots?",
+			"in": "https://192.168.12.34..",
+			"n1url": "http://192.168.12.34/",
+			"n2url": "http://192.168.12.34"
+		},
+		{
+			"description": "IPv4 with tailing dot and port",
+			"in": "https://192.168.12.34.:8080",
+			"n1url": "http://192.168.12.34:8080/",
+			"n2url": "http://192.168.12.34:8080"
+		},
+		{
+			"description": "case-insensitive general host",
+			"in": "https://WWW.EXAMPLE.COM",
+			"n1url": "http://www.example.com/",
+			"n2url": "http://www.example.com"
+		},
+		{
+			"description": "case-insensitive general host with path, query, and hash",
+			"in": "https://WWW.EXAMPLE.COM/PATH/to/Page?Xa=UP#ABC",
+			"n1url": "http://www.example.com/PATH/to/Page/?Xa=UP#ABC",
+			"n2url": "http://www.example.com"
+		},
+		{
+			"description": "case-insensitive general host with tailing dot",
+			"in": "https://WWW.EXAMPLE.COM.",
+			"n1url": "http://www.example.com/",
+			"n2url": "http://www.example.com"
+		},
+		{
+			"description": "IPv6 host",
+			"in": "https://[2001:0db8:bd05:01d2:288a:1fc0:0001:10ee]",
+			"n1url": "http://[2001:0db8:bd05:01d2:288a:1fc0:0001:10ee]/",
+			"n2url": "http://[2001:0db8:bd05:01d2:288a:1fc0:0001:10ee]"
+		},
+		{
+			"description": "IPv6 host port",
+			"in": "https://[2001:0db8:bd05:01d2:288a:1fc0:0001:10ee]:8080",
+			"n1url": "http://[2001:0db8:bd05:01d2:288a:1fc0:0001:10ee]:8080/",
+			"n2url": "http://[2001:0db8:bd05:01d2:288a:1fc0:0001:10ee]:8080"
+		},
+		{
+			"description": "case-insensitive IPv6 host",
+			"in": "https://[2001:0DB8:BD05:01D2:288A:1FC0:0001:10EE]",
+			"n1url": "http://[2001:0db8:bd05:01d2:288a:1fc0:0001:10ee]/",
+			"n2url": "http://[2001:0db8:bd05:01d2:288a:1fc0:0001:10ee]"
+		}
+	]
+}


### PR DESCRIPTION
New `normHost()` func is migrated from `normalizePunycodeHost()` and added new normalizing tasks:

- trimming tailing dots (except IPv6 address hostname)
- converting to lower case
    - because host part is case-insensitive, See: https://www.w3.org/TR/WD-html40-970708/htmlweb.html
