### PR TITLE
Improve optimize

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,3 +29,12 @@ issues:
       linters:
         - scopelint
         - exhaustruct
+
+linters-settings:
+  depguard:
+    rules:
+      main:
+        allow:
+         - $gostd
+         - "github.com/go-playground/validator/"
+         - "github.com/TeamMomentum/bs-url-normalizer/"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,12 +29,3 @@ issues:
       linters:
         - scopelint
         - exhaustruct
-
-linters-settings:
-  depguard:
-    rules:
-      main:
-        allow:
-         - $gostd
-         - "github.com/go-playground/validator/"
-         - "github.com/TeamMomentum/bs-url-normalizer/"

--- a/lib/urls/optimize.go
+++ b/lib/urls/optimize.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/go-playground/validator/v10"
@@ -56,7 +57,8 @@ var (
 		"itest.bbspink.com":               optimizeItest5chURL,
 	}
 
-	errEmptyURLString = errors.New("parse target URL is empty")
+	errEmptyURLString  = errors.New("parse target URL is empty")
+	errDigitsURLString = errors.New("parse target URL is digits")
 )
 
 func optimizeURL(ul *url.URL) *url.URL {
@@ -242,6 +244,10 @@ func optimizeItest5chURL(ul *url.URL) *url.URL {
 func parsePotentialURL(rawurl string) (*url.URL, error) {
 	if rawurl == "" {
 		return nil, errEmptyURLString
+	}
+
+	if _, err := strconv.Atoi(rawurl); err == nil {
+		return nil, errDigitsURLString
 	}
 
 	parsed, parseErr := url.Parse(rawurl)

--- a/lib/urls/optimize.go
+++ b/lib/urls/optimize.go
@@ -19,9 +19,6 @@ import (
 
 const (
 	itest5chDomain = "itest"
-
-	mobileapp1 = "mobileapp::1-"
-	mobileapp2 = "mobileapp::2-"
 )
 
 var (
@@ -166,11 +163,11 @@ func optimizeSocdmURL(ul *url.URL) *url.URL {
 		}
 	case "1":
 		if raw, ok := ul.Query()["appbundle"]; ok {
-			src = mobileapp2 + raw[0]
+			src = "mobileapp::2-" + raw[0]
 		}
 	case "2":
 		if raw, ok := ul.Query()["appbundle"]; ok {
-			src = mobileapp1 + raw[0]
+			src = "mobileapp::1-" + raw[0]
 		}
 	default:
 		return ul
@@ -193,14 +190,14 @@ g.doubleclick.net用正規化関数.
 */
 func optimizeDoubleClickURL(ul *url.URL) *url.URL {
 	if raw, ok := ul.Query()["msid"]; ok {
-		u, err := url.Parse(mobileapp2 + raw[0])
+		u, err := url.Parse("mobileapp::2-" + raw[0])
 		if err == nil {
 			return u
 		}
 	}
 
 	if raw, ok := ul.Query()["_package_name"]; ok {
-		u, err := url.Parse(mobileapp1 + raw[0])
+		u, err := url.Parse("mobileapp::1-" + raw[0])
 		if err == nil {
 			return u
 		}

--- a/lib/urls/optimize.go
+++ b/lib/urls/optimize.go
@@ -253,12 +253,10 @@ func parsePotentialURL(rawurl string) (*url.URL, error) {
 		return nil, errDigitsURLString
 	}
 
-	returnURLSchema := "http://"
-
 	parsed, parseErr := url.Parse(rawurl)
 	if parseErr != nil { // assumed case: `hello.世界.com:8080/page.html` (multibyte hostname with port number)
 		if host, tail, err := net.SplitHostPort(rawurl); err == nil && host != "" && tail != "" {
-			return url.Parse(returnURLSchema + rawurl) //nolint: wrapcheck // retry with http scheme
+			return url.Parse("http://" + rawurl) //nolint: wrapcheck // retry with http scheme
 		}
 
 		return nil, fmt.Errorf("url.Parse: %w", parseErr)
@@ -272,13 +270,13 @@ func parsePotentialURL(rawurl string) (*url.URL, error) {
 	}
 
 	if scheme == "" { // missing any scheme in rawurl
-		return url.Parse(returnURLSchema + rawurl) //nolint: wrapcheck // re-parse with `http://` scheme prefix
+		return url.Parse("http://" + rawurl) //nolint: wrapcheck // re-parse with `http://` scheme prefix
 	}
 
 	if parsed.Host == "" { // case: scheme exists but missing authority part
 		// Check if hostname was considered as the URL scheme
 		// See also: https://github.com/golang/go/issues/12585
-		if alt, err := url.Parse(returnURLSchema + rawurl); err == nil && parsed.Scheme == alt.Hostname() && alt.Port() != "" {
+		if alt, err := url.Parse("http://" + rawurl); err == nil && parsed.Scheme == alt.Hostname() && alt.Port() != "" {
 			return alt, nil
 		}
 	}

--- a/lib/urls/optimize.go
+++ b/lib/urls/optimize.go
@@ -19,6 +19,9 @@ import (
 
 const (
 	itest5chDomain = "itest"
+
+	mobileapp1 = "mobileapp::1-"
+	mobileapp2 = "mobileapp::2-"
 )
 
 var (
@@ -163,11 +166,11 @@ func optimizeSocdmURL(ul *url.URL) *url.URL {
 		}
 	case "1":
 		if raw, ok := ul.Query()["appbundle"]; ok {
-			src = "mobileapp::2-" + raw[0]
+			src = mobileapp2 + raw[0]
 		}
 	case "2":
 		if raw, ok := ul.Query()["appbundle"]; ok {
-			src = "mobileapp::1-" + raw[0]
+			src = mobileapp1 + raw[0]
 		}
 	default:
 		return ul
@@ -190,14 +193,14 @@ g.doubleclick.net用正規化関数.
 */
 func optimizeDoubleClickURL(ul *url.URL) *url.URL {
 	if raw, ok := ul.Query()["msid"]; ok {
-		u, err := url.Parse("mobileapp::2-" + raw[0])
+		u, err := url.Parse(mobileapp2 + raw[0])
 		if err == nil {
 			return u
 		}
 	}
 
 	if raw, ok := ul.Query()["_package_name"]; ok {
-		u, err := url.Parse("mobileapp::1-" + raw[0])
+		u, err := url.Parse(mobileapp1 + raw[0])
 		if err == nil {
 			return u
 		}

--- a/lib/urls/optimize.go
+++ b/lib/urls/optimize.go
@@ -253,10 +253,12 @@ func parsePotentialURL(rawurl string) (*url.URL, error) {
 		return nil, errDigitsURLString
 	}
 
+	returnURLSchema := "http://"
+
 	parsed, parseErr := url.Parse(rawurl)
 	if parseErr != nil { // assumed case: `hello.世界.com:8080/page.html` (multibyte hostname with port number)
 		if host, tail, err := net.SplitHostPort(rawurl); err == nil && host != "" && tail != "" {
-			return url.Parse("http://" + rawurl) //nolint: wrapcheck // retry with http scheme
+			return url.Parse(returnURLSchema + rawurl) //nolint: wrapcheck // retry with http scheme
 		}
 
 		return nil, fmt.Errorf("url.Parse: %w", parseErr)
@@ -270,13 +272,13 @@ func parsePotentialURL(rawurl string) (*url.URL, error) {
 	}
 
 	if scheme == "" { // missing any scheme in rawurl
-		return url.Parse("http://" + rawurl) //nolint: wrapcheck // re-parse with `http://` scheme prefix
+		return url.Parse(returnURLSchema + rawurl) //nolint: wrapcheck // re-parse with `http://` scheme prefix
 	}
 
 	if parsed.Host == "" { // case: scheme exists but missing authority part
 		// Check if hostname was considered as the URL scheme
 		// See also: https://github.com/golang/go/issues/12585
-		if alt, err := url.Parse("http://" + rawurl); err == nil && parsed.Scheme == alt.Hostname() && alt.Port() != "" {
+		if alt, err := url.Parse(returnURLSchema + rawurl); err == nil && parsed.Scheme == alt.Hostname() && alt.Port() != "" {
 			return alt, nil
 		}
 	}

--- a/lib/urls/optimize.go
+++ b/lib/urls/optimize.go
@@ -262,20 +262,7 @@ func parsePotentialURL(rawurl string) (*url.URL, error) {
 	}
 
 	if scheme == "" { // check if rawurl without scheme is url
-		reparsed, err := url.Parse("http://" + rawurl)
-		if err != nil {
-			return nil, fmt.Errorf("url.Parse: %w", err)
-		}
-
-		if reparsed.Path != "" {
-			return reparsed, nil
-		}
-
-		if strings.Contains(strings.Trim(reparsed.Hostname(), "."), ".") {
-			return reparsed, nil
-		}
-
-		return nil, errSeemsToBeNonURLString
+		return parsePotentialURLWithSchemeAdded(rawurl)
 	}
 
 	if parsed.Host == "" { // case: scheme exists but missing authority part
@@ -287,4 +274,21 @@ func parsePotentialURL(rawurl string) (*url.URL, error) {
 	}
 
 	return parsed, nil // non-http scheme URL (e.g. ftp://example.com/bar, data:,Hello%2C%20World!, etc)
+}
+
+func parsePotentialURLWithSchemeAdded(rawurl string) (*url.URL, error) {
+	parsed, err := url.Parse("http://" + rawurl)
+	if err != nil {
+		return nil, fmt.Errorf("url.Parse: %w", err)
+	}
+
+	if parsed.Path != "" {
+		return parsed, nil
+	}
+
+	if strings.Contains(strings.Trim(parsed.Hostname(), "."), ".") {
+		return parsed, nil
+	}
+
+	return nil, errSeemsToBeNonURLString
 }

--- a/lib/urls/optimize_test.go
+++ b/lib/urls/optimize_test.go
@@ -142,6 +142,12 @@ func Test_parsePotentialURL(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"digits",
+			"68167",
+			nil,
+			true,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/lib/urls/optimize_test.go
+++ b/lib/urls/optimize_test.go
@@ -143,8 +143,8 @@ func Test_parsePotentialURL(t *testing.T) {
 			false,
 		},
 		{
-			"digits",
-			"68167",
+			"string",
+			".example.",
 			nil,
 			true,
 		},


### PR DESCRIPTION
## 背景

[parsePotentialURL 関数](https://github.com/TeamMomentum/bs-url-normalizer/blob/master/lib/urls/optimize.go#L242-L276) に渡される引数 `rawurl` の値が数字であるケースがあるため、エラーとして処理したい。

## 修正

- エラー処理

```sh
$ make build
...
ok      github.com/TeamMomentum/bs-url-normalizer/lib/urls      1.226s
```